### PR TITLE
Add examples for custom search methods

### DIFF
--- a/examples/knn.rs
+++ b/examples/knn.rs
@@ -1,6 +1,7 @@
 use vpsearch::{BestCandidate, MetricSpace};
 
 use std::collections::HashSet;
+use num_traits::Bounded;
 
 #[derive(Clone, Debug)]
 struct PointN {
@@ -45,7 +46,7 @@ impl<Item: MetricSpace<Impl>, Impl> CountBasedNeighborhood<Item, Impl> {
     fn new(item_count: usize) -> Self {
         CountBasedNeighborhood {
             max_item_count: item_count,
-            max_observed_distance: <Item::Distance as Default>::default(),
+            max_observed_distance: <Item::Distance as Bounded>::min_value(),
             distance_x_index: Vec::<(Item::Distance, usize)>::new(),
         }
     }

--- a/examples/knn.rs
+++ b/examples/knn.rs
@@ -1,0 +1,95 @@
+use vpsearch::{BestCandidate, MetricSpace};
+
+use std::collections::HashSet;
+
+#[derive(Clone, Debug)]
+struct PointN {
+    data: Vec<f32>,
+}
+
+/// Point structure that will end up in the tree
+impl PointN {
+    pub fn new(data: &Vec<f32>) -> Self {
+        PointN { data: data.clone() }
+    }
+}
+
+/// The searching function
+impl MetricSpace for PointN {
+    type UserData = ();
+    type Distance = f32;
+
+    fn distance(&self, other: &Self, _: &Self::UserData) -> Self::Distance {
+        self.data
+            .iter()
+            .zip(other.data.iter())
+            .map(|(s, o)| (s - o).powi(2))
+            .sum::<f32>()
+            .sqrt()
+    }
+}
+
+/// Add custom search for finding the index of multiple points in a radius
+/// The index of all point with a euclidean distance strictly less than
+/// `max_distance` will be returned.
+struct RadiusBasedNeighborhood<Item: MetricSpace<Impl>, Impl> {
+    max_distance: Item::Distance,
+    ids: HashSet<usize>,
+}
+
+impl<Item: MetricSpace<Impl>, Impl> RadiusBasedNeighborhood<Item, Impl> {
+    /// Helper function for creating the ReturnByIndexInNeighborhood struct.
+    /// Here `max_distance` is an exclusive upper bound to the euclidean distance.
+    fn new(max_distance: Item::Distance) -> Self {
+        RadiusBasedNeighborhood {
+            max_distance,
+            ids: HashSet::<usize>::new()
+        }
+    }
+}
+
+/// Best candidate definitions that tracks of the index all the points
+/// within the radius of `distance` as specified in the `RadiusBasedNeighborhood`.
+impl<Item: MetricSpace<Impl> + Clone, Impl> BestCandidate<Item, Impl>
+    for RadiusBasedNeighborhood<Item, Impl>
+{
+    type Output = HashSet<usize>;
+
+    #[inline]
+    fn consider(
+        &mut self,
+        _: &Item,
+        distance: Item::Distance,
+        candidate_index: usize,
+        _: &Item::UserData,
+    ) {
+        // If the distance is lower than the bound we include the index
+        // in the result.
+        if distance < self.max_distance {
+            self.ids.insert(candidate_index);
+        }
+    }
+
+    #[inline]
+    fn distance(&self) -> Item::Distance { self.max_distance }
+    fn result(self, _: &Item::UserData) -> Self::Output { self.ids }
+}
+
+fn main() {
+    let points = vec![
+        PointN::new(&vec![2.0, 3.0]),
+        PointN::new(&vec![0.0, 1.0]),
+        PointN::new(&vec![4.0, 5.0])
+    ];
+    let tree = vpsearch::Tree::new(&points);
+
+    // Search with a distance of 0, expect no points to be returned
+    let expected = HashSet::new();
+    let actual = tree.find_nearest_custom(&PointN::new(&vec![1.0, 2.0]), &(), RadiusBasedNeighborhood::new(0.0f32));
+    assert_eq!(actual, expected);
+
+    // Search with a distance of 100, expect all points to be returned
+    let expected = [0,1,2].iter().cloned().collect::<HashSet<usize>>();
+    let actual = tree.find_nearest_custom(&PointN::new(&vec![1.0, 2.0]), &(), RadiusBasedNeighborhood::new(100.0f32));
+    assert_eq!(actual, expected)
+}

--- a/examples/knn.rs
+++ b/examples/knn.rs
@@ -29,29 +29,54 @@ impl MetricSpace for PointN {
     }
 }
 
-/// Add custom search for finding the index of multiple points in a radius
-/// The index of all point with a euclidean distance strictly less than
-/// `max_distance` will be returned.
-struct RadiusBasedNeighborhood<Item: MetricSpace<Impl>, Impl> {
-    max_distance: Item::Distance,
-    ids: HashSet<usize>,
+/// Add custom search for finding the index of the N nearest points
+struct CountBasedNeighborhood<Item: MetricSpace<Impl>, Impl> {
+    // Max amount of items
+    max_item_count: usize,
+    // The max distance we have observed so far
+    max_observed_distance: Item::Distance,
+    // A list of indexes no longer than max_item_count sorted by distance
+    distance_x_index: Vec<(Item::Distance, usize)>,
 }
 
-impl<Item: MetricSpace<Impl>, Impl> RadiusBasedNeighborhood<Item, Impl> {
-    /// Helper function for creating the ReturnByIndexInNeighborhood struct.
-    /// Here `max_distance` is an exclusive upper bound to the euclidean distance.
-    fn new(max_distance: Item::Distance) -> Self {
-        RadiusBasedNeighborhood {
-            max_distance,
-            ids: HashSet::<usize>::new()
+impl<Item: MetricSpace<Impl>, Impl> CountBasedNeighborhood<Item, Impl> {
+    /// Helper function for creating the CountBasedNeighborhood struct.
+    /// Here `item_count` is the amount of items returned, the k in knn.
+    fn new(item_count: usize) -> Self {
+        CountBasedNeighborhood {
+            max_item_count: item_count,
+            max_observed_distance: <Item::Distance as Default>::default(),
+            distance_x_index: Vec::<(Item::Distance, usize)>::new(),
         }
+    }
+
+    /// Insert a single index in the correct possition given that the
+    /// `distance_x_index` is already sorted.
+    fn insert_index(&mut self, index: usize, distance: Item::Distance) {
+        // Add the new item at the end of the list.
+        self.distance_x_index.push((distance, index));
+        // We only need to sort lists with more than one entry
+        if self.distance_x_index.len() > 1 {
+            // Start indexing at the end of the vector. Note that len() is 1 indexed.
+            let mut n = self.distance_x_index.len() - 1;
+            // at n is further than n -1 we swap the two.
+            // Prefrom a single insertion sort pass. If the distance of the element
+            while n > 0 && self.distance_x_index[n].0 < self.distance_x_index[n - 1].0 {
+                self.distance_x_index.swap(n, n - 1);
+                n = n - 1;
+            }
+            self.distance_x_index.truncate(self.max_item_count);
+        }
+        // Update the max observed distance, unwrap is safe because this function
+        // inserts a point and the `max_item_count` is more then 0.
+        self.max_observed_distance = self.distance_x_index.last().unwrap().0
     }
 }
 
 /// Best candidate definitions that tracks of the index all the points
 /// within the radius of `distance` as specified in the `RadiusBasedNeighborhood`.
 impl<Item: MetricSpace<Impl> + Clone, Impl> BestCandidate<Item, Impl>
-    for RadiusBasedNeighborhood<Item, Impl>
+    for CountBasedNeighborhood<Item, Impl>
 {
     type Output = HashSet<usize>;
 
@@ -63,33 +88,72 @@ impl<Item: MetricSpace<Impl> + Clone, Impl> BestCandidate<Item, Impl>
         candidate_index: usize,
         _: &Item::UserData,
     ) {
-        // If the distance is lower than the bound we include the index
-        // in the result.
-        if distance < self.max_distance {
-            self.ids.insert(candidate_index);
+        // Early out, no need to do track any points if the max return size is 0
+        if self.max_item_count == 0 {
+            return;
+        }
+
+        // If the distance is lower than the max_observed distance we
+        // need to add that index into the sorted_ids and update the
+        // `max_observed_distance`. If the sorted_ids is already at max
+        // capacity we drop the point with the max distance and find
+        // out what the new `max_observed_distance` is by looking at
+        // the last entry in the `distance_x_index` vector. We also
+        // include the point if the `distance_x_index` is not full yet.
+        if distance < self.max_observed_distance
+            || self.distance_x_index.len() < self.max_item_count
+        {
+            self.insert_index(candidate_index, distance);
         }
     }
 
     #[inline]
-    fn distance(&self) -> Item::Distance { self.max_distance }
-    fn result(self, _: &Item::UserData) -> Self::Output { self.ids }
+    fn distance(&self) -> Item::Distance {
+        // return distance of the Nth farthest as we have currently observed it.
+        // All other points currently in the state will be closer than this.
+        self.max_observed_distance
+    }
+
+    fn result(self, _: &Item::UserData) -> Self::Output {
+        // Convert the sorted indexes into a hash set droping the distance value.
+        self.distance_x_index
+            .into_iter()
+            .map(|(_, index)| index)
+            .collect::<HashSet<usize>>()
+    }
 }
 
 fn main() {
     let points = vec![
         PointN::new(&vec![2.0, 3.0]),
         PointN::new(&vec![0.0, 1.0]),
-        PointN::new(&vec![4.0, 5.0])
+        PointN::new(&vec![4.0, 5.0]),
     ];
     let tree = vpsearch::Tree::new(&points);
 
-    // Search with a distance of 0, expect no points to be returned
-    let expected = HashSet::new();
-    let actual = tree.find_nearest_custom(&PointN::new(&vec![1.0, 2.0]), &(), RadiusBasedNeighborhood::new(0.0f32));
+    // Search with a neigboord size of 1, expect a single points to be returned
+    let actual = tree.find_nearest_custom(
+        &PointN::new(&vec![1.0, 2.0]),
+        &(),
+        CountBasedNeighborhood::new(1),
+    );
+    assert_eq!(actual.len(), 1);
+
+    // Search with a neigboord size of 2, expect a two points to be returned
+    let expected = [0, 1].iter().cloned().collect::<HashSet<usize>>();
+    let actual = tree.find_nearest_custom(
+        &PointN::new(&vec![1.0, 2.0]),
+        &(),
+        CountBasedNeighborhood::new(2),
+    );
     assert_eq!(actual, expected);
 
-    // Search with a distance of 100, expect all points to be returned
-    let expected = [0,1,2].iter().cloned().collect::<HashSet<usize>>();
-    let actual = tree.find_nearest_custom(&PointN::new(&vec![1.0, 2.0]), &(), RadiusBasedNeighborhood::new(100.0f32));
+    // Search with a neigboord size of 10, expect all points to be returned
+    let expected = [0, 1, 2].iter().cloned().collect::<HashSet<usize>>();
+    let actual = tree.find_nearest_custom(
+        &PointN::new(&vec![1.0, 2.0]),
+        &(),
+        CountBasedNeighborhood::new(10),
+    );
     assert_eq!(actual, expected)
 }

--- a/examples/radius_nn.rs
+++ b/examples/radius_nn.rs
@@ -1,0 +1,107 @@
+use vpsearch::{BestCandidate, MetricSpace};
+
+use std::collections::HashSet;
+
+#[derive(Clone, Debug)]
+struct PointN {
+    data: Vec<f32>,
+}
+
+/// Point structure that will end up in the tree
+impl PointN {
+    pub fn new(data: &Vec<f32>) -> Self {
+        PointN { data: data.clone() }
+    }
+}
+
+/// The searching function
+impl MetricSpace for PointN {
+    type UserData = ();
+    type Distance = f32;
+
+    fn distance(&self, other: &Self, _: &Self::UserData) -> Self::Distance {
+        self.data
+            .iter()
+            .zip(other.data.iter())
+            .map(|(s, o)| (s - o).powi(2))
+            .sum::<f32>()
+            .sqrt()
+    }
+}
+
+/// Add custom search for finding the index of multiple points in a radius
+/// The index of all point with a euclidean distance strictly less than
+/// `max_distance` will be returned.
+struct RadiusBasedNeighborhood<Item: MetricSpace<Impl>, Impl> {
+    max_distance: Item::Distance,
+    ids: HashSet<usize>,
+}
+
+impl<Item: MetricSpace<Impl>, Impl> RadiusBasedNeighborhood<Item, Impl> {
+    /// Helper function for creating the RadiusBasedNeighborhood struct.
+    /// Here `max_distance` is an exclusive upper bound to the euclidean distance.
+    fn new(max_distance: Item::Distance) -> Self {
+        RadiusBasedNeighborhood {
+            max_distance,
+            ids: HashSet::<usize>::new(),
+        }
+    }
+}
+
+/// Best candidate definitions that tracks of the index all the points
+/// within the radius of `distance` as specified in the `RadiusBasedNeighborhood`.
+impl<Item: MetricSpace<Impl> + Clone, Impl> BestCandidate<Item, Impl>
+    for RadiusBasedNeighborhood<Item, Impl>
+{
+    type Output = HashSet<usize>;
+
+    #[inline]
+    fn consider(
+        &mut self,
+        _: &Item,
+        distance: Item::Distance,
+        candidate_index: usize,
+        _: &Item::UserData,
+    ) {
+        // If the distance is lower than the bound we include the index
+        // in the result.
+        if distance < self.max_distance {
+            self.ids.insert(candidate_index);
+        }
+    }
+
+    #[inline]
+    fn distance(&self) -> Item::Distance {
+        self.max_distance
+    }
+    fn result(self, _: &Item::UserData) -> Self::Output {
+        self.ids
+    }
+}
+
+fn main() {
+    let points = vec![
+        PointN::new(&vec![2.0, 3.0]),
+        PointN::new(&vec![0.0, 1.0]),
+        PointN::new(&vec![4.0, 5.0]),
+    ];
+    let tree = vpsearch::Tree::new(&points);
+
+    // Search with a distance of 0, expect no points to be returned
+    let expected = HashSet::new();
+    let actual = tree.find_nearest_custom(
+        &PointN::new(&vec![1.0, 2.0]),
+        &(),
+        RadiusBasedNeighborhood::new(0.0f32),
+    );
+    assert_eq!(actual, expected);
+
+    // Search with a distance of 100, expect all points to be returned
+    let expected = [0, 1, 2].iter().cloned().collect::<HashSet<usize>>();
+    let actual = tree.find_nearest_custom(
+        &PointN::new(&vec![1.0, 2.0]),
+        &(),
+        RadiusBasedNeighborhood::new(100.0f32),
+    );
+    assert_eq!(actual, expected)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@
 
 use std::cmp::Ordering;
 use std::ops::Add;
+use std::fmt::Debug;
 use std::marker::Sized;
 use num_traits::Bounded;
 
@@ -84,12 +85,12 @@ pub struct Owned<T>(T);
 /// /// That dummy struct disambiguates between yours and everyone else's impl for a tuple:
 /// struct MyXYCoordinates;
 /// impl MetricSpace<MyXYCoordinates> for (f32,f32) {/*…*/}
-pub trait MetricSpace<UserImplementationType=()> {
+pub trait MetricSpace<UserImplementationType = ()> {
     /// This is used as a context for comparisons. Use `()` if the elements already contain all the data you need.
     type UserData;
 
     /// This is a fancy way of saying it should be `f32` or `u32`
-    type Distance: Copy + PartialOrd + Bounded + Default + Add<Output = Self::Distance> ;
+    type Distance: Copy + PartialOrd + Bounded + Default + Debug + Add<Output = Self::Distance>;
 
     /**
      * This function must return distance between two items that meets triangle inequality.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@
 
 use std::cmp::Ordering;
 use std::ops::Add;
-use std::fmt::Debug;
 use std::marker::Sized;
 use num_traits::Bounded;
 
@@ -90,7 +89,7 @@ pub trait MetricSpace<UserImplementationType = ()> {
     type UserData;
 
     /// This is a fancy way of saying it should be `f32` or `u32`
-    type Distance: Copy + PartialOrd + Bounded + Default + Debug + Add<Output = Self::Distance>;
+    type Distance: Copy + PartialOrd + Bounded + Add<Output = Self::Distance>;
 
     /**
      * This function must return distance between two items that meets triangle inequality.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub trait MetricSpace<UserImplementationType=()> {
     type UserData;
 
     /// This is a fancy way of saying it should be `f32` or `u32`
-    type Distance: Copy + PartialOrd + Bounded + Add<Output=Self::Distance>;
+    type Distance: Copy + PartialOrd + Bounded + Default + Add<Output = Self::Distance> ;
 
     /**
      * This function must return distance between two items that meets triangle inequality.


### PR DESCRIPTION
Thanks for the library! I found it really useful but thought it would be really nice to include some examples of the uses of `find_nearest_custom`, this pull request adds two new examples that can be used to find all the neighbours in a radius or the N nearest neighbours. 

This also adds the `Default` and `Debug` traits to the `Distance` item, this makes it easier to build / debug these `BestCandidate` implementations. 

This fixes: https://github.com/kornelski/vpsearch/issues/1